### PR TITLE
Ensure OAuth scopes are created before creating UserPoolClient

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -548,6 +548,7 @@ Resources:
         - uwo-openhouse-api/events:manage
         - uwo-openhouse-api/openhouses:manage
       GenerateSecret: false
+    DependsOn: AdminPoolResourceServer
 
   AdminPoolResourceServer:
     Type: AWS::Cognito::UserPoolResourceServer


### PR DESCRIPTION
In an effort to solve ScopeDoesNotExistException.